### PR TITLE
Bump versions of libraries for gmail quick-start

### DIFF
--- a/gmail/quickstart/build.gradle
+++ b/gmail/quickstart/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.23.0'
-    compile 'com.google.oauth-client:google-oauth-client-jetty:1.23.0'
-    compile 'com.google.apis:google-api-services-gmail:v1-rev83-1.23.0'
+    compile 'com.google.api-client:google-api-client:1.30.10'
+    compile 'com.google.oauth-client:google-oauth-client-jetty:1.31.0'
+    compile 'com.google.apis:google-api-services-gmail:v1-rev20200919-1.30.10'
 }


### PR DESCRIPTION
These versions are pretty old it seemed worth updating.

Updated version of https://github.com/gsuitedevs/java-samples/pull/104. I have confirmed that all the code is working as expected and I am not getting any dependency errors.