### PR TITLE
fix typos in GmailQuickstart class comment

### DIFF
--- a/gmail/quickstart/src/main/java/GmailQuickstart.java
+++ b/gmail/quickstart/src/main/java/GmailQuickstart.java
@@ -36,7 +36,7 @@ import java.security.GeneralSecurityException;
 import java.util.Collections;
 import java.util.List;
 
-/* class to demonstarte use of Gmail list lalels API */
+/* class to demonstrate use of Gmail list labels API */
 public class GmailQuickstart {
     /** Application name. */
     private static final String APPLICATION_NAME = "Gmail API Java Quickstart";


### PR DESCRIPTION
Just noticed these typos whist doing the quickstart so I thought I would submit a PR to update.

# Description

Very simple, comment update only

Fixes #165