### PR TITLE
feat: added Java code snippets for Aliases, CourseWork, and Topics 

### DIFF
--- a/classroom/snippets/src/main/java/AddAliasToCourse.java
+++ b/classroom/snippets/src/main/java/AddAliasToCourse.java
@@ -1,0 +1,85 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// [START classroom_add_alias_to_course_class]
+
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.services.classroom.Classroom;
+import com.google.api.services.classroom.ClassroomScopes;
+import com.google.api.services.classroom.model.CourseAlias;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.IOException;
+import java.util.Collections;
+
+/* Class to demonstrate the use of Classroom Create Alias API. */
+public class AddAliasToCourse {
+  /**
+   * Add an alias on an existing course.
+   *
+   * @param courseId - id of the course to add an alias to.
+   * @return - newly created course alias.
+   * @throws IOException - if credentials file not found.
+   */
+  public static CourseAlias addAliasToCourse(String courseId) throws IOException {
+    /* Load pre-authorized user credentials from the environment.
+       TODO(developer) - See https://developers.google.com/identity for
+        guides on implementing OAuth2 for your application. */
+    GoogleCredentials credentials = GoogleCredentials.getApplicationDefault()
+        .createScoped(Collections.singleton(ClassroomScopes.CLASSROOM_COURSES));
+    HttpRequestInitializer requestInitializer = new HttpCredentialsAdapter(
+        credentials);
+
+    // Create the classroom API client.
+    Classroom service = new Classroom.Builder(new NetHttpTransport(),
+        GsonFactory.getDefaultInstance(),
+        requestInitializer)
+        .setApplicationName("Classroom samples")
+        .build();
+
+    // [START classroom_add_alias_to_course_code_snippet]
+
+    /* Create a new CourseAlias object with a project-wide alias. Project-wide aliases use a prefix
+    of "p:" and can only be seen and used by the application that created them. */
+    CourseAlias content = new CourseAlias()
+        .setAlias("p:biology_10");
+    CourseAlias courseAlias = null;
+
+    try {
+      courseAlias = service.courses().aliases().create(courseId, content)
+          .execute();
+      System.out.printf("Course alias created: %s \n", courseAlias.getAlias());
+    } catch (GoogleJsonResponseException e) {
+      //TODO (developer) - handle error appropriately
+      GoogleJsonError error = e.getDetails();
+      if (error.getCode() == 409) {
+        System.out.printf("The course alias already exists: %s.\n", content);
+      } else {
+        throw e;
+      }
+    } catch (Exception e) {
+      throw e;
+    }
+    return courseAlias;
+
+    // [END classroom_add_alias_to_course_code_snippet]
+
+  }
+}
+// [END classroom_add_alias_to_course_class]

--- a/classroom/snippets/src/main/java/CreateCourseWithAlias.java
+++ b/classroom/snippets/src/main/java/CreateCourseWithAlias.java
@@ -1,0 +1,89 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// [START classroom_create_course_with_alias_class]
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.services.classroom.Classroom;
+import com.google.api.services.classroom.ClassroomScopes;
+import com.google.api.services.classroom.model.Course;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.IOException;
+import java.util.Collections;
+
+/* Class to demonstrate how to create a course with an alias. */
+public class CreateCourseWithAlias {
+  /**
+   * Create a new course with an alias. Set the new course id to the desired alias.
+   *
+   * @return - newly created course.
+   * @throws IOException - if credentials file not found.
+   */
+  public static Course createCourseWithAlias() throws IOException {
+    /* Load pre-authorized user credentials from the environment.
+       TODO(developer) - See https://developers.google.com/identity for
+        guides on implementing OAuth2 for your application. */
+    GoogleCredentials credentials = GoogleCredentials.getApplicationDefault()
+        .createScoped(Collections.singleton(ClassroomScopes.CLASSROOM_COURSES));
+    HttpRequestInitializer requestInitializer = new HttpCredentialsAdapter(
+        credentials);
+
+    // Create the classroom API client.
+    Classroom service = new Classroom.Builder(new NetHttpTransport(),
+        GsonFactory.getDefaultInstance(),
+        requestInitializer)
+        .setApplicationName("Classroom samples")
+        .build();
+
+    // [START classroom_create_course_with_alias_code_snippet]
+
+    Course course = null;
+
+    /* Create a new Course with the alias set as the id field. Project-wide aliases use a prefix
+    of "p:" and can only be seen and used by the application that created them. */
+    Course content = new Course()
+        .setId("p:history_4_2022")
+        .setName("9th Grade History")
+        .setSection("Period 4")
+        .setDescriptionHeading("Welcome to 9th Grade History.")
+        .setOwnerId("me")
+        .setCourseState("PROVISIONED");
+
+    try {
+      course = service.courses().create(content).execute();
+      // Prints the new created course id and name
+      System.out.printf("Course created: %s (%s)\n", course.getName(), course.getId());
+    } catch (GoogleJsonResponseException e) {
+      //TODO (developer) - handle error appropriately
+      GoogleJsonError error = e.getDetails();
+      if (error.getCode() == 409) {
+        System.out.printf("The course alias already exists: %s.\n", content.getId());
+      } else {
+        throw e;
+      }
+    } catch (Exception e) {
+      throw e;
+    }
+    return course;
+
+    // [END classroom_create_course_with_alias_code_snippet]
+
+  }
+}
+// [END classroom_create_course_with_alias_class]

--- a/classroom/snippets/src/main/java/CreateCourseWork.java
+++ b/classroom/snippets/src/main/java/CreateCourseWork.java
@@ -1,0 +1,107 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// [START classroom_create_coursework_class]
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.services.classroom.Classroom;
+import com.google.api.services.classroom.ClassroomScopes;
+import com.google.api.services.classroom.model.CourseWork;
+import com.google.api.services.classroom.model.Date;
+import com.google.api.services.classroom.model.Link;
+import com.google.api.services.classroom.model.Material;
+import com.google.api.services.classroom.model.TimeOfDay;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/* Class to demonstrate the use of Classroom Create CourseWork API. */
+public class CreateCourseWork {
+  /**
+   * Creates course work.
+   *
+   * @param courseId - id of the course to create coursework in.
+   * @return - newly created CourseWork object.
+   * @throws IOException - if credentials file not found.
+   */
+  public static CourseWork createCourseWork(String courseId) throws IOException {
+    /* Load pre-authorized user credentials from the environment.
+       TODO(developer) - See https://developers.google.com/identity for
+        guides on implementing OAuth2 for your application. */
+    GoogleCredentials credentials = GoogleCredentials.getApplicationDefault()
+        .createScoped(Collections.singleton(ClassroomScopes.CLASSROOM_COURSEWORK_STUDENTS));
+    HttpRequestInitializer requestInitializer = new HttpCredentialsAdapter(
+        credentials);
+
+    // Create the classroom API client.
+    Classroom service = new Classroom.Builder(new NetHttpTransport(),
+        GsonFactory.getDefaultInstance(),
+        requestInitializer)
+        .setApplicationName("Classroom samples")
+        .build();
+
+    // [START classroom_create_coursework_code_snippet]
+
+    CourseWork courseWork = null;
+    try {
+      // Create a link to add as a material on course work.
+      Link articleLink = new Link()
+          .setTitle("SR-71 Blackbird")
+          .setUrl("https://www.lockheedmartin.com/en-us/news/features/history/blackbird.html");
+
+      // Create a list of Materials to add to course work.
+      List<Material> materials = Arrays.asList(new Material().setLink(articleLink));
+
+      /* Create new CourseWork object with the material attached.
+      Set workType to `ASSIGNMENT`. Possible values of workType can be found here:
+      https://developers.google.com/classroom/reference/rest/v1/CourseWorkType
+      Set state to `PUBLISHED`. Possible values of state can be found here:
+      https://developers.google.com/classroom/reference/rest/v1/courses.courseWork#courseworkstate */
+      CourseWork content = new CourseWork()
+          .setTitle("Supersonic aviation")
+          .setDescription("Read about how the SR-71 Blackbird, the world’s fastest and "
+              + "highest-flying manned aircraft, was built.")
+          .setMaterials(materials)
+          .setDueDate(new Date().setMonth(12).setDay(10).setYear(2022))
+          .setDueTime(new TimeOfDay().setHours(15).setMinutes(0))
+          .setWorkType("ASSIGNMENT")
+          .setState("PUBLISHED");
+
+      courseWork = service.courses().courseWork().create(courseId, content)
+          .execute();
+    } catch (GoogleJsonResponseException e) {
+      //TODO (developer) - handle error appropriately
+      GoogleJsonError error = e.getDetails();
+      if (error.getCode() == 404) {
+        System.out.printf("The courseId does not exist: %s.\n", courseId);
+      } else {
+        throw e;
+      }
+      throw e;
+    } catch (Exception e) {
+      throw e;
+    }
+    return courseWork;
+
+    // [END classroom_create_coursework_code_snippet]
+  }
+}
+// [END classroom_create_coursework_class]

--- a/classroom/snippets/src/main/java/CreateTopic.java
+++ b/classroom/snippets/src/main/java/CreateTopic.java
@@ -1,0 +1,81 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// [START classroom_create_topic_class]
+
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.services.classroom.Classroom;
+import com.google.api.services.classroom.ClassroomScopes;
+import com.google.api.services.classroom.model.Topic;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.IOException;
+import java.util.Collections;
+
+/* Class to demonstrate how to create a topic. */
+public class CreateTopic {
+  /**
+   * Create a new topic in a course.
+   *
+   * @param courseId - the id of the course to create a topic in.
+   * @return - newly created topic.
+   * @throws IOException - if credentials file not found.
+   */
+  public static Topic createTopic(String courseId) throws IOException {
+    /* Load pre-authorized user credentials from the environment.
+       TODO(developer) - See https://developers.google.com/identity for
+        guides on implementing OAuth2 for your application. */
+    GoogleCredentials credentials = GoogleCredentials.getApplicationDefault()
+        .createScoped(Collections.singleton(ClassroomScopes.CLASSROOM_TOPICS));
+    HttpRequestInitializer requestInitializer = new HttpCredentialsAdapter(
+        credentials);
+
+    // Create the classroom API client.
+    Classroom service = new Classroom.Builder(new NetHttpTransport(),
+        GsonFactory.getDefaultInstance(),
+        requestInitializer)
+        .setApplicationName("Classroom samples")
+        .build();
+
+    // [START classroom_create_topic_code_snippet]
+
+    Topic topic = null;
+    try {
+      // Create the new Topic.
+      Topic content = new Topic().setName("Semester 1");
+      topic = service.courses().topics().create(courseId, content).execute();
+      System.out.println("Topic id: " + topic.getTopicId() + "\n" + "Course id: " + courseId);
+    } catch (GoogleJsonResponseException e) {
+      //TODO (developer) - handle error appropriately
+      GoogleJsonError error = e.getDetails();
+      if (error.getCode() == 404) {
+        System.out.printf("The courseId does not exist: %s.\n", courseId);
+      } else {
+        throw e;
+      }
+    } catch (Exception e) {
+      throw e;
+    }
+    return topic;
+
+    // [END classroom_create_topic_code_snippet]
+
+  }
+}
+// [END classroom_create_topic_class]

--- a/classroom/snippets/src/main/java/DeleteTopic.java
+++ b/classroom/snippets/src/main/java/DeleteTopic.java
@@ -1,0 +1,76 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// [START classroom_delete_topic_class]
+
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.services.classroom.Classroom;
+import com.google.api.services.classroom.ClassroomScopes;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.IOException;
+import java.util.Collections;
+
+/* Class to demonstrate how to delete a topic. */
+public class DeleteTopic {
+  /**
+   * Delete a topic in a course.
+   *
+   * @param courseId - the id of the course where the topic belongs.
+   * @param topicId - the id of the topic to delete.
+   * @return - updated topic.
+   * @throws IOException - if credentials file not found.
+   */
+  public static void deleteTopic(String courseId, String topicId) throws IOException {
+    /* Load pre-authorized user credentials from the environment.
+     TODO(developer) - See https://developers.google.com/identity for
+      guides on implementing OAuth2 for your application. */
+    GoogleCredentials credentials = GoogleCredentials.getApplicationDefault()
+        .createScoped(Collections.singleton(ClassroomScopes.CLASSROOM_TOPICS));
+    HttpRequestInitializer requestInitializer = new HttpCredentialsAdapter(
+        credentials);
+
+    // Create the classroom API client.
+    Classroom service = new Classroom.Builder(new NetHttpTransport(),
+        GsonFactory.getDefaultInstance(),
+        requestInitializer)
+        .setApplicationName("Classroom samples")
+        .build();
+
+    // [START classroom_delete_topic_code_snippet]
+
+    try {
+      service.courses().topics().delete(courseId, topicId).execute();
+    } catch (GoogleJsonResponseException e) {
+      // TODO(developer) - handle error appropriately
+      GoogleJsonError error = e.getDetails();
+      if (error.getCode() == 404) {
+        System.out.printf("The courseId or topicId does not exist: %s, %s.\n", courseId, topicId);
+      } else {
+        throw e;
+      }
+    } catch (Exception e) {
+      throw e;
+    }
+
+    // [END classroom_delete_topic_code_snippet]
+
+  }
+}
+// [END classroom_delete_topic_class]

--- a/classroom/snippets/src/main/java/GetTopic.java
+++ b/classroom/snippets/src/main/java/GetTopic.java
@@ -1,0 +1,80 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// [START classroom_get_topic_class]
+
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.services.classroom.Classroom;
+import com.google.api.services.classroom.ClassroomScopes;
+import com.google.api.services.classroom.model.Topic;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.IOException;
+import java.util.Collections;
+
+/* Class to demonstrate how to get a topic. */
+public class GetTopic {
+  /**
+   * Get a topic in a course.
+   *
+   * @param courseId - the id of the course the topic belongs to.
+   * @param topicId - the id of the topic to retrieve.
+   * @return - the topic to retrieve.
+   * @throws IOException - if credentials file not found.
+   */
+  public static Topic getTopic(String courseId, String topicId) throws IOException {
+    /* Load pre-authorized user credentials from the environment.
+     TODO(developer) - See https://developers.google.com/identity for
+      guides on implementing OAuth2 for your application. */
+    GoogleCredentials credentials = GoogleCredentials.getApplicationDefault()
+        .createScoped(Collections.singleton(ClassroomScopes.CLASSROOM_TOPICS));
+    HttpRequestInitializer requestInitializer = new HttpCredentialsAdapter(
+        credentials);
+
+    // Create the classroom API client.
+    Classroom service = new Classroom.Builder(new NetHttpTransport(),
+        GsonFactory.getDefaultInstance(),
+        requestInitializer)
+        .setApplicationName("Classroom samples")
+        .build();
+
+    // [START classroom_get_topic_code_snippet]
+
+    Topic topic = null;
+    try {
+      // Get the topic.
+      topic = service.courses().topics().get(courseId, topicId).execute();
+    } catch (GoogleJsonResponseException e) {
+      //TODO (developer) - handle error appropriately
+      GoogleJsonError error = e.getDetails();
+      if (error.getCode() == 404) {
+        System.out.printf("The courseId or topicId does not exist: %s, %s.\n", courseId, topicId);
+      } else {
+        throw e;
+      }
+    } catch (Exception e) {
+      throw e;
+    }
+    return topic;
+
+    // [END classroom_get_topic_code_snippet]
+
+  }
+}
+// [END classroom_get_topic_class]

--- a/classroom/snippets/src/main/java/ListTopics.java
+++ b/classroom/snippets/src/main/java/ListTopics.java
@@ -1,0 +1,98 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// [START classroom_list_topic_class]
+
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.services.classroom.Classroom;
+import com.google.api.services.classroom.ClassroomScopes;
+import com.google.api.services.classroom.model.ListTopicResponse;
+import com.google.api.services.classroom.model.Topic;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/* Class to demonstrate how to list topics in a course. */
+public class ListTopics {
+  /**
+   * List topics in a course.
+   *
+   * @param courseId - the id of the course to retrieve topics for.
+   * @return - the list of topics in the course that the caller is permitted to view.
+   * @throws IOException - if credentials file not found.
+   */
+  public static List<Topic> listTopics(String courseId) throws IOException {
+    /* Load pre-authorized user credentials from the environment.
+     TODO(developer) - See https://developers.google.com/identity for
+      guides on implementing OAuth2 for your application. */
+    GoogleCredentials credentials = GoogleCredentials.getApplicationDefault()
+        .createScoped(Collections.singleton(ClassroomScopes.CLASSROOM_TOPICS));
+    HttpRequestInitializer requestInitializer = new HttpCredentialsAdapter(
+        credentials);
+
+    // Create the classroom API client.
+    Classroom service = new Classroom.Builder(new NetHttpTransport(),
+        GsonFactory.getDefaultInstance(),
+        requestInitializer)
+        .setApplicationName("Classroom samples")
+        .build();
+
+    // [START classroom_list_topic_code_snippet]
+
+    List<Topic> topics = new ArrayList<>();
+    String pageToken = null;
+
+    try {
+      do {
+        ListTopicResponse response = service.courses().topics().list(courseId)
+            .setPageSize(100)
+            .setPageToken(pageToken)
+            .execute();
+        topics.addAll(response.getTopic());
+        pageToken = response.getNextPageToken();
+      } while (pageToken != null);
+
+      if (topics.isEmpty()) {
+        System.out.println("No topics found.");
+      } else {
+        for (Topic topic : topics) {
+          System.out.printf("%s (%s)\n", topic.getName(), topic.getTopicId());
+        }
+      }
+    } catch (GoogleJsonResponseException e) {
+      //TODO (developer) - handle error appropriately
+      GoogleJsonError error = e.getDetails();
+      if (error.getCode() == 404) {
+        System.out.printf("The courseId does not exist: %s.\n", courseId);
+      } else {
+        throw e;
+      }
+    } catch (Exception e) {
+      throw e;
+    }
+    return topics;
+
+    // [END classroom_list_topic_code_snippet]
+
+  }
+}
+// [END classroom_list_topic_class]

--- a/classroom/snippets/src/main/java/UpdateTopic.java
+++ b/classroom/snippets/src/main/java/UpdateTopic.java
@@ -1,0 +1,89 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// [START classroom_update_topic_class]
+
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.services.classroom.Classroom;
+import com.google.api.services.classroom.ClassroomScopes;
+import com.google.api.services.classroom.model.Topic;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.IOException;
+import java.util.Collections;
+
+/* Class to demonstrate how to update one or more fields in a topic. */
+public class UpdateTopic {
+  /**
+   * Update one or more fields in a topic in a course.
+   *
+   * @param courseId - the id of the course where the topic belongs.
+   * @param topicId - the id of the topic to update.
+   * @return - updated topic.
+   * @throws IOException - if credentials file not found.
+   */
+  public static Topic updateTopic(String courseId, String topicId) throws IOException {
+    /* Load pre-authorized user credentials from the environment.
+     TODO(developer) - See https://developers.google.com/identity for
+      guides on implementing OAuth2 for your application. */
+    GoogleCredentials credentials = GoogleCredentials.getApplicationDefault()
+        .createScoped(Collections.singleton(ClassroomScopes.CLASSROOM_TOPICS));
+    HttpRequestInitializer requestInitializer = new HttpCredentialsAdapter(
+        credentials);
+
+    // Create the classroom API client.
+    Classroom service = new Classroom.Builder(new NetHttpTransport(),
+        GsonFactory.getDefaultInstance(),
+        requestInitializer)
+        .setApplicationName("Classroom samples")
+        .build();
+
+    // [START classroom_update_topic_code_snippet]
+
+    Topic topic = null;
+    try {
+      // Retrieve the topic to update.
+      Topic topicToUpdate = service.courses().topics().get(courseId, topicId).execute();
+
+      // Update the name field for the topic retrieved.
+      topicToUpdate.setName("Semester 2");
+
+      /* Call the patch endpoint and set the updateMask query parameter to the field that needs to
+       be updated. */
+      topic = service.courses().topics().patch(courseId, topicId, topicToUpdate)
+          .set("updateMask", "name")
+          .execute();
+    } catch(GoogleJsonResponseException e) {
+      // TODO(developer) - handle error appropriately
+      GoogleJsonError error = e.getDetails();
+      if (error.getCode() == 404) {
+        System.out.printf("The courseId or topicId does not exist: %s, %s.\n", courseId, topicId);
+      } else {
+        throw e;
+      }
+    } catch (Exception e) {
+      throw e;
+    }
+    return topic;
+
+    // [END classroom_update_topic_code_snippet]
+
+  }
+}
+// [END classroom_update_topic_class]

--- a/classroom/snippets/src/test/java/BaseTest.java
+++ b/classroom/snippets/src/test/java/BaseTest.java
@@ -80,6 +80,10 @@ public class BaseTest {
   }
 
   public void deleteCourse(String courseId) throws IOException {
+    // updating the course state to be archived so the course can be deleted.
+    Course course = service.courses().get(courseId).execute();
+    course.setCourseState("ARCHIVED");
+    this.service.courses().update(courseId, course).execute();
     this.service.courses().delete(courseId).execute();
   }
 }

--- a/classroom/snippets/src/test/java/TestAddAliasToCourse.java
+++ b/classroom/snippets/src/test/java/TestAddAliasToCourse.java
@@ -1,0 +1,34 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import com.google.api.services.classroom.model.CourseAlias;
+import java.io.IOException;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+// Unit test class for Add Alias classroom snippet
+public class TestAddAliasToCourse extends BaseTest {
+
+  @Test
+  public void testAddCourseAlias() throws IOException {
+    CourseAlias courseAlias = AddAliasToCourse.addAliasToCourse(testCourse.getId());
+    List<CourseAlias> courseAliases = service.courses().aliases()
+        .list(testCourse.getId()
+        ).execute()
+        .getAliases();
+    Assert.assertNotNull("Course alias not returned.", courseAlias);
+    Assert.assertTrue("No course aliases exist.", courseAliases.size() > 0);
+  }
+}

--- a/classroom/snippets/src/test/java/TestCreateCourseWithAlias.java
+++ b/classroom/snippets/src/test/java/TestCreateCourseWithAlias.java
@@ -1,0 +1,36 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import com.google.api.services.classroom.model.Course;
+import com.google.api.services.classroom.model.CourseAlias;
+import java.io.IOException;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+// Unit test class for Create Alias classroom snippet
+public class TestCreateCourseWithAlias extends BaseTest {
+
+  @Test
+  public void testCreateCourseWithAlias() throws IOException {
+    Course course = CreateCourseWithAlias.createCourseWithAlias();
+    List<CourseAlias> courseAliases = service.courses().aliases()
+        .list(course.getId()
+        ).execute()
+        .getAliases();
+    Assert.assertNotNull("Course not returned.", course);
+    Assert.assertTrue("No course aliases exist.", courseAliases.size() > 0);
+    deleteCourse(course.getId());
+  }
+}

--- a/classroom/snippets/src/test/java/TestCreateCourseWork.java
+++ b/classroom/snippets/src/test/java/TestCreateCourseWork.java
@@ -1,0 +1,28 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import com.google.api.services.classroom.model.CourseWork;
+import java.io.IOException;
+import org.junit.Assert;
+import org.junit.Test;
+
+// Unit test class for Create Coursework classroom snippet
+public class TestCreateCourseWork extends BaseTest {
+
+  @Test
+  public void testCreateCoursework() throws IOException {
+    CourseWork courseWork = CreateCourseWork.createCourseWork(testCourse.getId());
+    Assert.assertNotNull("Coursework not returned.", courseWork);
+  }
+}

--- a/classroom/snippets/src/test/java/TestCreateTopic.java
+++ b/classroom/snippets/src/test/java/TestCreateTopic.java
@@ -1,0 +1,28 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import com.google.api.services.classroom.model.Topic;
+import java.io.IOException;
+import org.junit.Assert;
+import org.junit.Test;
+
+// Unit test class for Create Topic classroom snippet
+public class TestCreateTopic extends BaseTest {
+
+  @Test
+  public void testCreateTopic() throws IOException {
+    Topic topic = CreateTopic.createTopic(testCourse.getId());
+    Assert.assertNotNull("Topic not returned.", topic);
+  }
+}

--- a/classroom/snippets/src/test/java/TestDeleteTopic.java
+++ b/classroom/snippets/src/test/java/TestDeleteTopic.java
@@ -1,0 +1,15 @@
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.services.classroom.model.Topic;
+import java.io.IOException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestDeleteTopic extends BaseTest {
+  @Test
+  public void testDeleteTopic() throws IOException {
+    Topic topic = CreateTopic.createTopic(testCourse.getId());
+    DeleteTopic.deleteTopic(testCourse.getId(), topic.getTopicId());
+    Assert.assertThrows(GoogleJsonResponseException.class,
+        () -> GetTopic.getTopic(testCourse.getId(), topic.getTopicId()));
+  }
+}

--- a/classroom/snippets/src/test/java/TestDeleteTopic.java
+++ b/classroom/snippets/src/test/java/TestDeleteTopic.java
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.classroom.model.Topic;
 import java.io.IOException;

--- a/classroom/snippets/src/test/java/TestGetTopic.java
+++ b/classroom/snippets/src/test/java/TestGetTopic.java
@@ -1,0 +1,31 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import com.google.api.services.classroom.model.Topic;
+import java.io.IOException;
+import org.junit.Assert;
+import org.junit.Test;
+
+// Unit test class for Get Topic classroom snippet
+public class TestGetTopic extends BaseTest {
+
+  @Test
+  public void testGetTopic() throws IOException {
+    Topic topic = CreateTopic.createTopic(testCourse.getId());
+    Topic getTopic = GetTopic.getTopic(testCourse.getId(), topic.getTopicId());
+    Assert.assertNotNull("Topic could not be created.", topic);
+    Assert.assertNotNull("Topic could not be retrieved.", getTopic);
+    Assert.assertEquals("Wrong topic was retrieved.", topic, getTopic);
+  }
+}

--- a/classroom/snippets/src/test/java/TestListTopics.java
+++ b/classroom/snippets/src/test/java/TestListTopics.java
@@ -1,0 +1,31 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import com.google.api.services.classroom.model.Topic;
+import java.io.IOException;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+// Unit test class for List Topics classroom snippet
+public class TestListTopics extends BaseTest {
+
+  @Test
+  public void testListTopics() throws IOException {
+    CreateTopic.createTopic(testCourse.getId());
+    List<Topic> listTopics = ListTopics.listTopics(testCourse.getId());
+    Assert.assertNotNull("Topics could not be retrieved.", listTopics);
+    Assert.assertFalse("No topics were retrieved.", listTopics.size() == 0);
+  }
+}

--- a/classroom/snippets/src/test/java/TestUpdateTopic.java
+++ b/classroom/snippets/src/test/java/TestUpdateTopic.java
@@ -1,0 +1,28 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import com.google.api.services.classroom.model.Topic;
+import java.io.IOException;
+import org.junit.Assert;
+import org.junit.Test;
+
+// Unit test class for Update Topic classroom snippet
+public class TestUpdateTopic extends BaseTest {
+  @Test
+  public void testUpdateTopic() throws IOException {
+    Topic topic = CreateTopic.createTopic(testCourse.getId());
+    System.out.println("New topic created: " + topic.getName());
+    Topic updatedTopic = UpdateTopic.updateTopic(testCourse.getId(), topic.getTopicId());
+    Assert.assertNotEquals("Topic name was not updated.", topic.getName(), updatedTopic.getName());
+  }
+}


### PR DESCRIPTION
# Description

This PR builds on the current Java code snippets to add missing code snippets to the external Classroom API documentation.

Fixes # (issue)

I added the following classes: 
- CreateAlias
- AddAlias
- CreateCourseWork
- GetTopic
- CreateTopic
- UpdateTopic
- DeleteTopic
- ListTopics

## Is it been tested?

- [x ] Development testing done

## Checklist

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] I have performed a peer-reviewed with team member(s)
- [x ] I have commented my code, particularly in hard-to-understand areas
- [Doc changes can be made once the code is merged. ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [N/A ] Any dependent changes have been merged and published in downstream modules
