### PR TITLE
fix: updating FileList query field name

### DIFF
--- a/drive/snippets/drive_v3/src/main/java/SearchFile.java
+++ b/drive/snippets/drive_v3/src/main/java/SearchFile.java
@@ -60,7 +60,7 @@ public class SearchFile {
       FileList result = service.files().list()
           .setQ("mimeType='image/jpeg'")
           .setSpaces("drive")
-          .setFields("nextPageToken, items(id, title)")
+          .setFields("nextPageToken, files(id, title)")
           .setPageToken(pageToken)
           .execute();
       for (File file : result.getFiles()) {


### PR DESCRIPTION
renaming `items` (v2) to `files` (v3)

# Description

After the v2 to v3 API change, the query field `items` changed to `files` and thus needs to be renamed.

Fixes b/412962079

## Is it been tested?

- [X] Development testing done
